### PR TITLE
Add Playwright E2E tests

### DIFF
--- a/frontend/E2E/auth-and-stepinput.spec.ts
+++ b/frontend/E2E/auth-and-stepinput.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+
+const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJ1c2VybmFtZSI6InRlc3R1c2VyIiwidXNlcklkIjoiMSIsImV4cCI6NDEwMjQ0NDgwMH0.signature';
+const user = { id: '1', email: 'test@example.com', username: 'testuser' };
+
+test('login redirects to list', async ({ page }) => {
+  await page.route('**/api/auth/login', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ token, user }),
+    });
+  });
+
+  await page.goto('/login');
+  await page.fill('#email', user.email);
+  await page.fill('#password', 'password');
+  await page.click('button[type="submit"]');
+  await page.waitForURL('/bbs/list');
+  await expect(page).toHaveURL(/\/bbs\/list/);
+});
+
+test('step input wizard flow', async ({ page }) => {
+  await page.addInitScript(token => {
+    localStorage.setItem('token', token);
+  }, token);
+
+  await page.goto('/step-input');
+  await expect(page.getByText('Welcome to Our App')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Next' }).click();
+  await expect(page.getByLabel('Full Name')).toBeVisible();
+
+  await page.fill('#name', 'John Doe');
+  await page.fill('#email', 'john@example.com');
+  await page.fill('#phone', '1234567890');
+  await page.click('form button[type="submit"]');
+  await page.getByRole('button', { name: 'Next' }).click();
+
+  await page.check('#notifications');
+  await page.check('#dark');
+  await page.click('form button[type="submit"]');
+  await page.getByRole('button', { name: 'Next' }).click();
+
+  await expect(page.getByText('Review Your Information')).toBeVisible();
+  await expect(page.getByText('John Doe')).toBeVisible();
+  await expect(page.getByText('john@example.com')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Complete' }).click();
+  await page.waitForURL('/');
+  await expect(page).toHaveURL('/');
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
     "sort-locales": "node scripts/sortLocales.js",
     "test": "jest --config jest.config.js",
     "test:coverage": "jest --config jest.config.js --coverage",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test:e2e": "playwright test --config playwright.config.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = 3000;
+export default defineConfig({
+  testDir: './E2E',
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chrome',
+      use: { browserName: 'chromium', channel: 'chrome' },
+    },
+    {
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 5'], browserName: 'chromium' },
+    },
+    {
+      name: 'webkit',
+      use: { browserName: 'webkit' },
+    },
+  ],
+  webServer: {
+    command: 'pnpm run dev',
+    cwd: './frontend',
+    port: PORT,
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "backend"
   ],
   "devDependencies": {
+    "@playwright/test": "^1.52.0",
     "dotenv-cli": "^8.0.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.52.0
+        version: 1.52.0
       dotenv-cli:
         specifier: ^8.0.0
         version: 8.0.0
@@ -947,6 +950,11 @@ packages:
   '@pkgr/core@0.2.7':
     resolution: {integrity: sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.52.0':
+    resolution: {integrity: sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@prisma/client@6.7.0':
     resolution: {integrity: sha512-+k61zZn1XHjbZul8q6TdQLpuI/cvyfil87zqK2zpreNIXyXtpUv3+H/oM69hcsFcZXaokHJIzPAt5Z8C8eK2QA==}
@@ -2417,6 +2425,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3491,6 +3504,16 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  playwright-core@1.52.0:
+    resolution: {integrity: sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.52.0:
+    resolution: {integrity: sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -5242,6 +5265,10 @@ snapshots:
 
   '@pkgr/core@0.2.7': {}
 
+  '@playwright/test@1.52.0':
+    dependencies:
+      playwright: 1.52.0
+
   '@prisma/client@6.7.0(prisma@6.7.0(typescript@5.8.3))(typescript@5.8.3)':
     optionalDependencies:
       prisma: 6.7.0(typescript@5.8.3)
@@ -6951,6 +6978,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -8360,6 +8390,14 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  playwright-core@1.52.0: {}
+
+  playwright@1.52.0:
+    dependencies:
+      playwright-core: 1.52.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
## Summary
- install `@playwright/test`
- add Playwright configuration
- create E2E flow covering login and step wizard
- expose `test:e2e` script
- update Playwright config command

## Testing
- `pnpm exec playwright test --config frontend/playwright.config.ts --reporter=line --timeout=0` *(fails: spawn /bin/sh ENOENT)*

------
https://chatgpt.com/codex/tasks/task_b_684173f9d58c8320923593958dc228b7